### PR TITLE
Only enable test report commenting in PR

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -58,7 +58,7 @@ jobs:
         check_name: 'Android Test Report'
         token: ${{ secrets.GITHUB_TOKEN }}
         report_paths: '**/build/test-results/testDebugUnitTest/TEST-*.xml'
-        comment: true
+        comment: ${{ github.event_name == 'pull_request' }}
         updateComment: true
 
     - name: Generate kover coverage report
@@ -71,7 +71,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         path: 'client/android/app/build/reports/kover/reportDebug.xml'
         title: Android Code Coverage
-        update-comment: true
+        update-comment: ${{ github.event_name == 'pull_request' }}
         coverage-counter-type: LINE
         min-coverage-overall: 70
         min-coverage-changed-files: 70

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -52,6 +52,6 @@ jobs:
           check_name: Rust Test Report
           fail_on_failure: true
           require_tests: true
-          comment: true
+          comment: ${{ github.event_name == 'pull_request' }}
           summary: ${{ steps.cargo_reporter.outputs.summary }}
 


### PR DESCRIPTION
A number of actions have a check for this internally, but some don't and will fail on master merges if it's switched on.