### PR TITLE
Support deleted lesson state

### DIFF
--- a/client/rust/shared/src/data/lessons/api.rs
+++ b/client/rust/shared/src/data/lessons/api.rs
@@ -19,6 +19,7 @@ pub(super) struct LessonResponse {
     pub language1: String,
     pub language2: String,
     pub owner: String,
+    pub is_deleted: bool,
     pub updated_at: i64,
 }
 

--- a/client/rust/shared/src/data/lessons/api_mocks.rs
+++ b/client/rust/shared/src/data/lessons/api_mocks.rs
@@ -6,13 +6,17 @@ use super::api::{LessonResponse, LessonsResponse};
 
 #[cfg(test)]
 pub(crate) trait LessonApiMocks {
-    fn mock_lessons_success(&mut self, count: u16) -> Mock;
+    fn mock_lessons_success(&mut self, count: u16, with_deleted: u16) -> Mock;
     fn mock_lessons_failure(&mut self) -> Mock;
 }
 
 #[cfg(test)]
 impl LessonApiMocks for Server {
-    fn mock_lessons_success(&mut self, count: u16) -> Mock {
+    /// Generates a mock lessons api response.
+    /// 
+    /// The number of lessons is specified by count
+    /// The first 'with_deleted' lessons will be marked as deleted
+    fn mock_lessons_success(&mut self, count: u16, with_deleted: u16) -> Mock {
         let epoc_time = Utc::now().timestamp();
 
         let lessons: Vec<LessonResponse> = (0..count).map(|i|
@@ -23,6 +27,7 @@ impl LessonApiMocks for Server {
                 language1: "en".to_string(),
                 language2: "jp".to_string(),
                 owner: "owner".to_string(),
+                is_deleted: i < with_deleted,
                 updated_at: epoc_time + (i as i64),
             }
         ).collect();

--- a/client/rust/shared/src/domain/lessons.rs
+++ b/client/rust/shared/src/domain/lessons.rs
@@ -63,11 +63,23 @@ mod tests {
         let mut server = mockito::Server::new_async().await;
         let domain = fake_domain(server.url() + "/").unwrap();
 
-        server.deref_mut().mock_lessons_success(5);
+        server.deref_mut().mock_lessons_success(5, 0);
 
         let r = domain.get_lessons().await;
         assert!(r.is_ok());
         assert_eq!(5, r.unwrap().len());
+    }
+
+    #[tokio::test]
+    async fn test_get_lessons_doesnt_persist_deleted_items() {
+        let mut server = mockito::Server::new_async().await;
+        let domain = fake_domain(server.url() + "/").unwrap();
+
+        server.deref_mut().mock_lessons_success(5, 1);
+
+        let r = domain.get_lessons().await;
+        assert!(r.is_ok());
+        assert_eq!(4, r.unwrap().len());
     }
 
     #[tokio::test]

--- a/server/api/serializers.py
+++ b/server/api/serializers.py
@@ -40,7 +40,7 @@ class LessonSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Lesson
-        fields = ['id', 'title', 'type', 'language1', 'language2', 'owner']
+        fields = ['id', 'title', 'type', 'language1', 'language2', 'owner', 'is_deleted']
 
     def to_representation(self, instance):
         data = super().to_representation(instance)

--- a/server/api/serializers.py
+++ b/server/api/serializers.py
@@ -44,6 +44,12 @@ class LessonSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         data = super().to_representation(instance)
+        # If the lesson is deleted, we can suppress details from the response as this will not be used.
+        if data['is_deleted'] == 1:
+            data['title'] = ''
+            data['language1'] = ''
+            data['language2'] = ''
+            data['owner'] = ''
         data['updated_at'] = int(time.mktime(instance.updated_at.timetuple()))  # Add updated at in utc format
         return data
 

--- a/server/api/views.py
+++ b/server/api/views.py
@@ -55,11 +55,9 @@ class LessonViewSet(mixins.ListModelMixin, mixins.RetrieveModelMixin, mixins.Upd
     serializer_class = LessonSerializer
     authentication_classes = (JWTAuthentication, )
 
-    def destroy(self, request, *args, **kwargs):
-        lesson = self.get_object()
-        lesson.is_deleted = True
-        lesson.save()
-        return Response(data='delete success')
+    def perform_destroy(self, instance):
+         instance.is_deleted = True
+         instance.save()
 
     def get_queryset(self):
         qs = Q()

--- a/server/ui/templates/lesson.html
+++ b/server/ui/templates/lesson.html
@@ -61,7 +61,7 @@
             <input class="inline-block text-lg font-semi-bold px-5 py-2 leading-none border rounded-md text-white border-white hover:border-blue-600 hover:text-blue-600 bg-blue-600 hover:bg-white ml-2 lg:mt-0"
                    type="button" value="Cancel" onclick="location.href='{% url 'lessons_page' %}';"/>
             <input class="inline-block text-lg font-semi-bold px-5 py-2 leading-none border rounded-md text-white border-white hover:border-red-600 hover:text-red-600 bg-red-600 hover:bg-white ml-2 lg:mt-0"
-                   type="button" value="Delete lesson"/>
+                   type="submit" value="Delete Lesson" name="delete" />
         </div>
         {{ formset.management_form }}
         <table class="edit-table">

--- a/server/ui/views.py
+++ b/server/ui/views.py
@@ -70,7 +70,10 @@ def study_page(request):
 
 def lessons_page(request):
     return render(request, "lessons.html", {
-        "lessons": Lesson.objects.filter(owner=request.user.id)
+        "lessons": Lesson.objects.filter(
+            owner=request.user.id,
+            is_deleted=False,
+        )
     })
 
 
@@ -96,6 +99,10 @@ def lesson_page(request, id):
     if request.method == "POST":
         formset = FactFormSet(request.POST, form_kwargs={'lesson': lesson})
         is_form_valid = form.is_valid()
+        if request.POST.get('delete'): #submitted via the delete button?
+            lesson.is_deleted = True
+            lesson.save()
+            return HttpResponseRedirect(f"/lessons")
         is_formset_valid = formset.is_valid()
         if is_form_valid and is_formset_valid:
             form.save()


### PR DESCRIPTION
In order to assist lesson syncing between server and clients, lessons will be marked as deleted rather than actually deleted. This adds support in the different areas for this:

Website:
 - Filter the lesson list to now show owner's lessons that are marked as deleted.
 - Wire the delete button to submit delete flag to the backend.

Api:
- Suppress any values stored in the lesson for deleted entries in order to minimise the size of the response data. We only need to know the uuid + deleted state for these lessons.

All Clients:
- Suppress the lessons in the lessons list which are marked as deleted.
- Remove any deleted lessons present in the db that are returned as deleted from the api.