### PR TITLE
Update tokio runtime setup

### DIFF
--- a/client/rust/shared/src/data/lessons/repository.rs
+++ b/client/rust/shared/src/data/lessons/repository.rs
@@ -20,7 +20,7 @@ impl From<LessonResponse> for LessonData {
     }
 }
 
-static REFRESH_TASK: &str = "REFRESH_TASK";
+static LESSONS_REFRESH_TASK: &str = "LESSONS_REFRESH_TASK";
 static LESSONS_LAST_SYNC_TIME: &str = "LESSONS_LAST_SYNC_TIME";
 #[allow(unused)] // Implementing shortly
 const PAGE_SIZE: u8 = 2;
@@ -48,7 +48,7 @@ impl LessonRepository {
         let settings = self.settings.clone();
         log::trace!("lesson_repo - spawning refresh task");
 
-        self.runtime.spawn(REFRESH_TASK.into(), async move {
+        self.runtime.spawn(LESSONS_REFRESH_TASK.into(), async move {
             log::trace!("lesson_repo - refresh task started");
             log::trace!("lesson_repo - refresh task completed");
 

--- a/client/rust/shared/src/domain/auth.rs
+++ b/client/rust/shared/src/domain/auth.rs
@@ -29,7 +29,6 @@ pub trait Auth {
     fn logout(&self) -> impl std::future::Future<Output = DomainResult<()>> + Send;
 }
 
-
 #[uniffi::export(async_runtime = "tokio")]
 impl Auth for Domain {
     async fn get_session(&self) -> DomainResult<Session> {
@@ -84,10 +83,9 @@ mod tests {
 
         let r = domain.login("user".to_string(), "password".to_string()).await;
         assert!(r.is_ok());
-        //let _ = tokio::time::sleep(Duration::from_secs(60));
         let s = domain.get_session().await;
         assert!(s.is_ok());
-        assert!(Session::Authenticated("user".into()) == s.unwrap());
+        assert_eq!(Session::Authenticated("user".into()), s.unwrap());
     }
 
     #[tokio::test]

--- a/client/rust/shared/src/domain/runtime.rs
+++ b/client/rust/shared/src/domain/runtime.rs
@@ -5,6 +5,13 @@ pub(crate) struct Runtime {
     tasks: HashMap<String, JoinHandle<()>>,
 }
 
+lazy_static::lazy_static! {
+    static ref RUNTIME: tokio::runtime::Runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("LingoLessons Thread")
+        .build().unwrap();
+}
+
 impl Runtime {
     pub(crate) fn new() -> Self {
         Self {
@@ -20,7 +27,7 @@ impl Runtime {
         if let Some(task) = self.tasks.get(&key) {
             task.abort();
         }
-        let x: JoinHandle<()> = tokio::task::spawn(future);
+        let x: JoinHandle<()> = RUNTIME.spawn(future);
         self.tasks.insert(key, x);
     }
     

--- a/server/env.dev
+++ b/server/env.dev
@@ -1,6 +1,6 @@
 DEBUG=1
 SECRET_KEY='django-insecure-3*0-+=-n7$m@v4%hhmm(^$@!z9q25f9ob6(w_$+8e##s&=u%8+'
-DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1]
+DJANGO_ALLOWED_HOSTS=localhost 127.0.0.1 [::1] 10.0.2.2
 SQL_ENGINE=django.db.backends.postgresql
 SQL_DATABASE=dev_db
 SQL_USER=dev_user


### PR DESCRIPTION
- Set up the Tokio runtime.
- Needed by the clients when tasks are spawned outside tests.
