### PR TITLE
Rust: Fix bug where lessons were being duplicated

### DIFF
--- a/client/rust/shared/src/data/db/migrations/02-lessons/up.sql
+++ b/client/rust/shared/src/data/db/migrations/02-lessons/up.sql
@@ -1,5 +1,5 @@
 CREATE TABLE IF NOT EXISTS lesson(
-  id TEXT,
+  id TEXT PRIMARY KEY,
   title TEXT NOT NULL,
   type INTEGER NOT NULL,
   language1 TEXT,

--- a/client/rust/shared/src/data/lessons/db.rs
+++ b/client/rust/shared/src/data/lessons/db.rs
@@ -155,4 +155,22 @@ mod tests {
         let lessons = db.get_lessons().unwrap();
         assert_eq!(4, lessons.len());
     }
+
+    #[test]
+    fn test_lessons_primary_key() {
+        let db = Db::open("blah.txt".to_string()).unwrap();
+        let r = db.get_lessons();
+        assert!(r.unwrap().is_empty());
+
+        let lessons = DbFixtures::create_lessons(1);
+        let lesson = lessons.get(0).unwrap();
+        db.set_lesson(&lesson).unwrap();
+        let r = db.get_lessons();
+        assert_eq!(1, r.unwrap().len());
+
+        // Should update rather than insert a duplicate
+        db.set_lesson(&lesson).unwrap();
+        let r = db.get_lessons();
+        assert_eq!(1, r.unwrap().len());
+    }
 }


### PR DESCRIPTION
- Forgot to specify the primary key on the lessons table, which was leading to duplicate lessons during the sync phase.