### PR TITLE
Nix env setup: check architecture and create appropriate emulator based on system arch

### DIFF
--- a/client/default.nix
+++ b/client/default.nix
@@ -9,12 +9,12 @@
       enable = true;
       version = [ "28.0.13004108" ]; # available versions defined in https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/androidndk-pkgs/default.nix
     };
-    platforms.version = [ "34" "35" ];
-    buildTools.version = [ "34.0.0" "35.0.0" ];
+    platforms.version = [ "35" ];
+    buildTools.version = [ "35.0.0" ];
     systemImageTypes = [ "google_apis_playstore" ];
     emulator = {
       enable = true;
-      version = "34.1.9";
+      version = "35.5.2";
     };
     sources.enable = true;
     systemImages.enable = true;
@@ -54,10 +54,14 @@
   enterShell = ''
       echo 'READY';
       export ANDROID_HOME=$(which android | sed -E 's/(.*libexec\/android-sdk).*/\1/')
-      export ANDROID_NDK_HOME=$ANDROID_HOME/ndk/28.0.13004108
-      export ANDROID_NDKSDK_ROOT=$ANDROID_NDK_HOME
+      export ANDROID_NDK_HOME=$ANDROID_HOME/ndk/28.0.13004108/
+      export ANDROID_NDK_ROOT=$ANDROID_NDK_HOME
       export PATH=$ANDROID_HOME/cmdline-tools/latest/bin:$PATH
   '';
   
-  scripts.create-avd.exec = "avdmanager create avd --force --name 'Pixel6a' --package 'system-images;android-34-ext10;google_apis_playstore;x86_64' --device 'pixel_6a'";
+  scripts.create-avd.exec = if builtins.currentSystem == "aarch64-linux" || builtins.currentSystem == "aarch64-darwin"
+  then "avdmanager create avd --force --name 'Pixel' --package 'system-images;android-35;google_apis_playstore;arm64-v8a' --device 'pixel_6a'"
+  else "avdmanager create avd --force --name 'Pixel' --package 'system-images;android-35;google_apis_playstore;x86_64' --device 'pixel_6a'";
+
+  scripts.avd.exec = "nohup $ANDROID_HOME/emulator/emulator -avd Pixel &";
 }

--- a/client/nohup.out
+++ b/client/nohup.out
@@ -1,0 +1,871 @@
+INFO         | Android emulator version 35.5.2.0 (build_id 13003482) (CL:N/A)
+INFO         | Graphics backend: gfxstream
+INFO         | Found systemPath /nix/store/hzl1xnx8w48is86566s446mq7zm7dk80-androidsdk/libexec/android-sdk/system-images/android-35/google_apis_playstore/arm64-v8a/
+INFO         | Increasing RAM size to 2048MB
+INFO         | Checking system compatibility:
+INFO         |   Checking: hasSufficientDiskSpace
+INFO         |      Ok: Disk space requirements to run avd: `Pixel` are met
+INFO         |   Checking: hasSufficientHwGpu
+INFO         |      Ok: Hardware GPU requirements to run avd: `Pixel` are passed
+INFO         |   Checking: hasSufficientSystem
+INFO         |      Ok: System requirements to run avd: `Pixel` are met
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_btn_xr_environment_living_room_day_clicked() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_btn_xr_environment_living_room_night_clicked() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_new_posture_requested(int) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_posture_selection_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_new_resizable_requested(PresetEmulatorSizeType) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_resizable_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_xr_environment_mode_changed(int) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_xr_environment_mode_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_xr_input_mode_changed(int) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_xr_input_mode_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_sleep_timer_done() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_unfold_timer_done() (:0, )
+INFO         | Storing crashdata in: /tmp/android-amiceli/emu-crash-35.5.2.db, detection is enabled for process: 89721
+INFO         | Guest Driver: Auto (ext controls)
+library_mode host gpu mode host
+INFO         | Initializing hardware OpenGLES emulation support
+I0721 21:27:58.040830 5065f00 opengles.cpp:285] android_startOpenglesRenderer: gpu info
+I0721 21:27:58.040840 5065f00 opengles.cpp:286] 
+INFO         | HealthMonitor disabled.
+INFO         | initIcdPaths: ICD set to 'swiftshader', using Swiftshader ICD
+INFO         | Setting ICD filenames for the loader = /nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/vk_swiftshader_icd.json:/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/vk_swiftshader_icd.json
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib]
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] (posix): begin
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] (posix,darwin): call dlopen
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] (posix,darwin): failed, try again with [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib]
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] failed (posix). dlerror: []
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib]
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib] (posix): begin
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib] (posix,darwin): call dlopen
+
+INFO         | Added library: /nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib
+INFO         | Selecting Vulkan device: SwiftShader Device (LLVM 10.0.0), Version: 1.2.0
+INFO         | Supports id properties, got a vulkan device UUID
+INFO         | SharedLibrary::open for [/System/Library/Frameworks/OpenGL.framework/OpenGL]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [/System/Library/Frameworks/OpenGL.framework/OpenGL] (posix): begin
+
+INFO         | SharedLibrary::open for [/System/Library/Frameworks/OpenGL.framework/OpenGL] (posix,darwin): call dlopen
+
+INFO         | SharedLibrary::open for [libshadertranslator.dylib]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [libshadertranslator.dylib] (posix): begin
+
+INFO         | SharedLibrary::open for [libshadertranslator.dylib] (posix,darwin): call dlopen
+
+INFO         | Initializing VkEmulation features:
+INFO         |     glInteropSupported: false
+INFO         |     useDeferredCommands: true
+INFO         |     createResourceWithRequirements: true
+INFO         |     useVulkanComposition: false
+INFO         |     useVulkanNativeSwapchain: false
+INFO         |     enable guestRenderDoc: false
+INFO         |     ASTC LDR emulation mode: 2
+INFO         |     enable ETC2 emulation: true
+INFO         |     enable Ycbcr emulation: false
+INFO         |     guestVulkanOnly: false
+INFO         |     useDedicatedAllocations: false
+INFO         | Graphics Adapter Vendor Google (Apple)
+INFO         | Graphics Adapter Android Emulator OpenGL ES Translator (Apple M3)
+INFO         | Graphics API Version OpenGL ES 3.0 (4.1 Metal - 89.4)
+INFO         | Graphics API Extensions GL_OES_EGL_sync GL_OES_EGL_image GL_OES_EGL_image_external GL_OES_depth24 GL_OES_depth32 GL_OES_element_index_uint GL_OES_texture_float GL_OES_texture_float_linear GL_OES_compressed_paletted_texture GL_OES_compressed_ETC1_RGB8_texture GL_OES_depth_texture GL_OES_texture_npot GL_OES_rgb8_rgba8 GL_EXT_color_buffer_float GL_EXT_color_buffer_half_float GL_EXT_texture_format_BGRA8888 GL_APPLE_texture_format_BGRA8888 
+INFO         | Graphics Device Extensions N/A
+INFO         | Sending adb public key [QAAAAIVjas+z4g2zV2PZy4jj+mLM9NhvmJz2yjVCQ4y+i5AkE1yQ1Qb99SEdLqSFyYxr1XwHDo20Y7HphQP2r1Yp+DE6j8cn6TUVj/0vvBLIR+z6/yW6JrYpRJoQCRfGShHWx1t3z2yHayK85lxxjBfLZPohjJhIwBOH93e/dkHzEOIkSM2c2dN+O5hX9gBXNFItznXZqfSTV+4bSknrRho8TXlxwCxCswk4UkXrbCsCdQmrHfFHVOAftL4f0QYJML6JoeHCQKGLqejgb1839FDDdEwDp9WXp9lCzCqW5/hLz/s8hnC/93vY0hC+Dh6K31rLihekJ/YfnlCOSefCErb55kh19deffD/sXhLBcfWnkB49jhvDf+HWSGbjQYUPMbBd+Rl4YGo2Fa0rJJ7Oolo36InMudIrCd7gojXYtj9vO6XPA9I93ftQgZMWYoFP3tbQRpWDnfBDT3JG5PZNFt3nV42OQSKB3O9MFJ/Y72Ev9mWxAx6vd1HYq+pT9YSR+K1znApOM+vVydeAczfXTUxknAGJWCExpPLKtLF268XCudhDhWXNBjxDDIteZcCR4gssOn87tHnf+fdrOZPqb98NqUd/Fs+bo0gRIVp3t0neF8KEdiYATfAKCVrjchziA66pSSMvHbRCnf+pn1Z9d+8mAjvLzRW51KipNbP40f8i9KUMGTIRPgEAAQA= amiceli@unknown]
+INFO         | Userspace boot properties:
+INFO         |   androidboot.boot_devices=a003600.virtio_mmio
+INFO         |   androidboot.dalvik.vm.heapsize=512m
+INFO         |   androidboot.debug.hwui.renderer=skiagl
+INFO         |   androidboot.hardware=ranchu
+INFO         |   androidboot.hardware.gltransport=pipe
+INFO         |   androidboot.hardware.vulkan=ranchu
+INFO         |   androidboot.logcat=*:V
+INFO         |   androidboot.opengles.version=196608
+INFO         |   androidboot.qemu=1
+INFO         |   androidboot.qemu.adb.pubkey=QAAAAIVjas+z4g2zV2PZy4jj+mLM9NhvmJz2yjVCQ4y+i5AkE1yQ1Qb99SEdLqSFyYxr1XwHDo20Y7HphQP2r1Yp+DE6j8cn6TUVj/0vvBLIR+z6/yW6JrYpRJoQCRfGShHWx1t3z2yHayK85lxxjBfLZPohjJhIwBOH93e/dkHzEOIkSM2c2dN+O5hX9gBXNFItznXZqfSTV+4bSknrRho8TXlxwCxCswk4UkXrbCsCdQmrHfFHVOAftL4f0QYJML6JoeHCQKGLqejgb1839FDDdEwDp9WXp9lCzCqW5/hLz/s8hnC/93vY0hC+Dh6K31rLihekJ/YfnlCOSefCErb55kh19deffD/sXhLBcfWnkB49jhvDf+HWSGbjQYUPMbBd+Rl4YGo2Fa0rJJ7Oolo36InMudIrCd7gojXYtj9vO6XPA9I93ftQgZMWYoFP3tbQRpWDnfBDT3JG5PZNFt3nV42OQSKB3O9MFJ/Y72Ev9mWxAx6vd1HYq+pT9YSR+K1znApOM+vVydeAczfXTUxknAGJWCExpPLKtLF268XCudhDhWXNBjxDDIteZcCR4gssOn87tHnf+fdrOZPqb98NqUd/Fs+bo0gRIVp3t0neF8KEdiYATfAKCVrjchziA66pSSMvHbRCnf+pn1Z9d+8mAjvLzRW51KipNbP40f8i9KUMGTIRPgEAAQA= amiceli@unknown
+INFO         |   androidboot.qemu.avd_name=Pixel
+INFO         |   androidboot.qemu.camera_hq_edge_processing=0
+INFO         |   androidboot.qemu.camera_protocol_ver=1
+INFO         |   androidboot.qemu.cpuvulkan.version=4202496
+INFO         |   androidboot.qemu.gltransport.drawFlushInterval=800
+INFO         |   androidboot.qemu.gltransport.name=pipe
+INFO         |   androidboot.qemu.hwcodec.avcdec=2
+INFO         |   androidboot.qemu.hwcodec.hevcdec=2
+INFO         |   androidboot.qemu.hwcodec.vpxdec=2
+INFO         |   androidboot.qemu.settings.system.screen_off_timeout=2147483647
+INFO         |   androidboot.qemu.virtiowifi=1
+INFO         |   androidboot.qemu.vsync=60
+INFO         |   androidboot.serialno=EMULATOR35X5X2X0
+INFO         |   androidboot.vbmeta.digest=017677f8986b0ac374dfb8d37fd142d50a77bda4a20142da493c5a4c3b962b87
+INFO         |   androidboot.vbmeta.hash_alg=sha256
+INFO         |   androidboot.vbmeta.size=6720
+INFO         |   androidboot.veritymode=enforcing
+INFO         | Monitoring duration of emulator setup.
+WARNING      | The emulator now requires a signed jwt token for gRPC access! Use the -grpc flag if you really want an open unprotected grpc port
+INFO         | Using security allow list from: /nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib/emulator_access.json
+WARNING      | *** Basic token auth should only be used by android-studio ***
+INFO         | The active JSON Web Key Sets can be found here: /Users/amiceli/Library/Caches/TemporaryItems/avd/running/89721/jwks/134f417d-5016-48bc-a770-97b42a3c023d/active.jwk
+INFO         | Scanning /Users/amiceli/Library/Caches/TemporaryItems/avd/running/89721/jwks/134f417d-5016-48bc-a770-97b42a3c023d for jwk keys.
+INFO         | Started GRPC server at 127.0.0.1:8554, security: Local, auth: +token
+INFO         | Advertising in: /Users/amiceli/Library/Caches/TemporaryItems/avd/running/pid_89721.ini
+INFO         | Setting display: 0 configuration to: 320x640, dpi: 160x160 
+INFO         | setDisplayActiveConfig 0
+INFO         | Checking system compatibility:
+INFO         |   Checking: hasSufficientDiskSpace
+INFO         |      Ok: Disk space requirements to run avd: `Pixel` are met
+INFO         |   Checking: hasSufficientHwGpu
+INFO         |      Ok: Hardware GPU requirements to run avd: `Pixel` are passed
+INFO         |   Checking: hasSufficientSystem
+INFO         |      Ok: System requirements to run avd: `Pixel` are met
+INFO         | Loading snapshot 'default_boot'...
+WARNING      | Client not connected yet. Ignoring message!
+WARNING      | Client not connected yet. Ignoring message!
+WARNING      | Client not connected yet. Ignoring message!
+WARNING      | Unknown XR viewport mode requested: 0, ignored.
+
+INFO         | Successfully loaded snapshot 'default_boot'
+ERROR        | Failed to find ColorBuffer:0
+INFO         | Activated packet streamer for bluetooth emulation
+INFO         | Wait for emulator (pid 89721) 20 seconds to shutdown gracefully before kill;you can set environment variable ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL(in seconds) to change the default value (20 seconds)
+
+INFO         | Saving with gfxstream=1
+ERROR        | Failed to restore previous context: 12297
+INFO         | Android emulator version 35.5.2.0 (build_id 13003482) (CL:N/A)
+INFO         | Graphics backend: gfxstream
+INFO         | Found systemPath /nix/store/hzl1xnx8w48is86566s446mq7zm7dk80-androidsdk/libexec/android-sdk/system-images/android-35/google_apis_playstore/arm64-v8a/
+INFO         | Increasing RAM size to 2048MB
+INFO         | Checking system compatibility:
+INFO         |   Checking: hasSufficientDiskSpace
+INFO         |      Ok: Disk space requirements to run avd: `Pixel` are met
+INFO         |   Checking: hasSufficientHwGpu
+INFO         |      Ok: Hardware GPU requirements to run avd: `Pixel` are passed
+INFO         |   Checking: hasSufficientSystem
+INFO         |      Ok: System requirements to run avd: `Pixel` are met
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_btn_xr_environment_living_room_day_clicked() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_btn_xr_environment_living_room_night_clicked() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_new_posture_requested(int) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_posture_selection_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_new_resizable_requested(PresetEmulatorSizeType) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_resizable_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_xr_environment_mode_changed(int) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_xr_environment_mode_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_xr_input_mode_changed(int) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_xr_input_mode_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_sleep_timer_done() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_unfold_timer_done() (:0, )
+INFO         | Storing crashdata in: /tmp/android-amiceli/emu-crash-35.5.2.db, detection is enabled for process: 90315
+INFO         | Guest Driver: Auto (ext controls)
+library_mode host gpu mode host
+INFO         | Initializing hardware OpenGLES emulation support
+I0721 21:29:16.852702 5065f00 opengles.cpp:285] android_startOpenglesRenderer: gpu info
+I0721 21:29:16.852717 5065f00 opengles.cpp:286] 
+INFO         | HealthMonitor disabled.
+INFO         | initIcdPaths: ICD set to 'swiftshader', using Swiftshader ICD
+INFO         | Setting ICD filenames for the loader = /nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/vk_swiftshader_icd.json:/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/vk_swiftshader_icd.json
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib]
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] (posix): begin
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] (posix,darwin): call dlopen
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] (posix,darwin): failed, try again with [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib]
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] failed (posix). dlerror: []
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib]
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib] (posix): begin
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib] (posix,darwin): call dlopen
+
+INFO         | Added library: /nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib
+INFO         | Selecting Vulkan device: SwiftShader Device (LLVM 10.0.0), Version: 1.2.0
+INFO         | Supports id properties, got a vulkan device UUID
+INFO         | SharedLibrary::open for [/System/Library/Frameworks/OpenGL.framework/OpenGL]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [/System/Library/Frameworks/OpenGL.framework/OpenGL] (posix): begin
+
+INFO         | SharedLibrary::open for [/System/Library/Frameworks/OpenGL.framework/OpenGL] (posix,darwin): call dlopen
+
+INFO         | SharedLibrary::open for [libshadertranslator.dylib]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [libshadertranslator.dylib] (posix): begin
+
+INFO         | SharedLibrary::open for [libshadertranslator.dylib] (posix,darwin): call dlopen
+
+INFO         | Initializing VkEmulation features:
+INFO         |     glInteropSupported: false
+INFO         |     useDeferredCommands: true
+INFO         |     createResourceWithRequirements: true
+INFO         |     useVulkanComposition: false
+INFO         |     useVulkanNativeSwapchain: false
+INFO         |     enable guestRenderDoc: false
+INFO         |     ASTC LDR emulation mode: 2
+INFO         |     enable ETC2 emulation: true
+INFO         |     enable Ycbcr emulation: false
+INFO         |     guestVulkanOnly: false
+INFO         |     useDedicatedAllocations: false
+INFO         | Graphics Adapter Vendor Google (Apple)
+INFO         | Graphics Adapter Android Emulator OpenGL ES Translator (Apple M3)
+INFO         | Graphics API Version OpenGL ES 3.0 (4.1 Metal - 89.4)
+INFO         | Graphics API Extensions GL_OES_EGL_sync GL_OES_EGL_image GL_OES_EGL_image_external GL_OES_depth24 GL_OES_depth32 GL_OES_element_index_uint GL_OES_texture_float GL_OES_texture_float_linear GL_OES_compressed_paletted_texture GL_OES_compressed_ETC1_RGB8_texture GL_OES_depth_texture GL_OES_texture_npot GL_OES_rgb8_rgba8 GL_EXT_color_buffer_float GL_EXT_color_buffer_half_float GL_EXT_texture_format_BGRA8888 GL_APPLE_texture_format_BGRA8888 
+INFO         | Graphics Device Extensions N/A
+INFO         | Sending adb public key [QAAAAIVjas+z4g2zV2PZy4jj+mLM9NhvmJz2yjVCQ4y+i5AkE1yQ1Qb99SEdLqSFyYxr1XwHDo20Y7HphQP2r1Yp+DE6j8cn6TUVj/0vvBLIR+z6/yW6JrYpRJoQCRfGShHWx1t3z2yHayK85lxxjBfLZPohjJhIwBOH93e/dkHzEOIkSM2c2dN+O5hX9gBXNFItznXZqfSTV+4bSknrRho8TXlxwCxCswk4UkXrbCsCdQmrHfFHVOAftL4f0QYJML6JoeHCQKGLqejgb1839FDDdEwDp9WXp9lCzCqW5/hLz/s8hnC/93vY0hC+Dh6K31rLihekJ/YfnlCOSefCErb55kh19deffD/sXhLBcfWnkB49jhvDf+HWSGbjQYUPMbBd+Rl4YGo2Fa0rJJ7Oolo36InMudIrCd7gojXYtj9vO6XPA9I93ftQgZMWYoFP3tbQRpWDnfBDT3JG5PZNFt3nV42OQSKB3O9MFJ/Y72Ev9mWxAx6vd1HYq+pT9YSR+K1znApOM+vVydeAczfXTUxknAGJWCExpPLKtLF268XCudhDhWXNBjxDDIteZcCR4gssOn87tHnf+fdrOZPqb98NqUd/Fs+bo0gRIVp3t0neF8KEdiYATfAKCVrjchziA66pSSMvHbRCnf+pn1Z9d+8mAjvLzRW51KipNbP40f8i9KUMGTIRPgEAAQA= amiceli@unknown]
+INFO         | Userspace boot properties:
+INFO         |   androidboot.boot_devices=a003600.virtio_mmio
+INFO         |   androidboot.dalvik.vm.heapsize=512m
+INFO         |   androidboot.debug.hwui.renderer=skiagl
+INFO         |   androidboot.hardware=ranchu
+INFO         |   androidboot.hardware.gltransport=pipe
+INFO         |   androidboot.hardware.vulkan=ranchu
+INFO         |   androidboot.logcat=*:V
+INFO         |   androidboot.opengles.version=196608
+INFO         |   androidboot.qemu=1
+INFO         |   androidboot.qemu.adb.pubkey=QAAAAIVjas+z4g2zV2PZy4jj+mLM9NhvmJz2yjVCQ4y+i5AkE1yQ1Qb99SEdLqSFyYxr1XwHDo20Y7HphQP2r1Yp+DE6j8cn6TUVj/0vvBLIR+z6/yW6JrYpRJoQCRfGShHWx1t3z2yHayK85lxxjBfLZPohjJhIwBOH93e/dkHzEOIkSM2c2dN+O5hX9gBXNFItznXZqfSTV+4bSknrRho8TXlxwCxCswk4UkXrbCsCdQmrHfFHVOAftL4f0QYJML6JoeHCQKGLqejgb1839FDDdEwDp9WXp9lCzCqW5/hLz/s8hnC/93vY0hC+Dh6K31rLihekJ/YfnlCOSefCErb55kh19deffD/sXhLBcfWnkB49jhvDf+HWSGbjQYUPMbBd+Rl4YGo2Fa0rJJ7Oolo36InMudIrCd7gojXYtj9vO6XPA9I93ftQgZMWYoFP3tbQRpWDnfBDT3JG5PZNFt3nV42OQSKB3O9MFJ/Y72Ev9mWxAx6vd1HYq+pT9YSR+K1znApOM+vVydeAczfXTUxknAGJWCExpPLKtLF268XCudhDhWXNBjxDDIteZcCR4gssOn87tHnf+fdrOZPqb98NqUd/Fs+bo0gRIVp3t0neF8KEdiYATfAKCVrjchziA66pSSMvHbRCnf+pn1Z9d+8mAjvLzRW51KipNbP40f8i9KUMGTIRPgEAAQA= amiceli@unknown
+INFO         |   androidboot.qemu.avd_name=Pixel
+INFO         |   androidboot.qemu.camera_hq_edge_processing=0
+INFO         |   androidboot.qemu.camera_protocol_ver=1
+INFO         |   androidboot.qemu.cpuvulkan.version=4202496
+INFO         |   androidboot.qemu.gltransport.drawFlushInterval=800
+INFO         |   androidboot.qemu.gltransport.name=pipe
+INFO         |   androidboot.qemu.hwcodec.avcdec=2
+INFO         |   androidboot.qemu.hwcodec.hevcdec=2
+INFO         |   androidboot.qemu.hwcodec.vpxdec=2
+INFO         |   androidboot.qemu.settings.system.screen_off_timeout=2147483647
+INFO         |   androidboot.qemu.virtiowifi=1
+INFO         |   androidboot.qemu.vsync=60
+INFO         |   androidboot.serialno=EMULATOR35X5X2X0
+INFO         |   androidboot.vbmeta.digest=017677f8986b0ac374dfb8d37fd142d50a77bda4a20142da493c5a4c3b962b87
+INFO         |   androidboot.vbmeta.hash_alg=sha256
+INFO         |   androidboot.vbmeta.size=6720
+INFO         |   androidboot.veritymode=enforcing
+INFO         | Monitoring duration of emulator setup.
+WARNING      | The emulator now requires a signed jwt token for gRPC access! Use the -grpc flag if you really want an open unprotected grpc port
+INFO         | Using security allow list from: /nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib/emulator_access.json
+WARNING      | *** Basic token auth should only be used by android-studio ***
+INFO         | The active JSON Web Key Sets can be found here: /Users/amiceli/Library/Caches/TemporaryItems/avd/running/90315/jwks/0542dd95-7d09-41a8-a654-f5c9d7f2a2e4/active.jwk
+INFO         | Scanning /Users/amiceli/Library/Caches/TemporaryItems/avd/running/90315/jwks/0542dd95-7d09-41a8-a654-f5c9d7f2a2e4 for jwk keys.
+INFO         | Started GRPC server at 127.0.0.1:8554, security: Local, auth: +token
+INFO         | Advertising in: /Users/amiceli/Library/Caches/TemporaryItems/avd/running/pid_90315.ini
+INFO         | Setting display: 0 configuration to: 320x640, dpi: 160x160 
+INFO         | setDisplayActiveConfig 0
+INFO         | Checking system compatibility:
+INFO         |   Checking: hasSufficientDiskSpace
+INFO         |      Ok: Disk space requirements to run avd: `Pixel` are met
+INFO         |   Checking: hasSufficientHwGpu
+INFO         |      Ok: Hardware GPU requirements to run avd: `Pixel` are passed
+INFO         |   Checking: hasSufficientSystem
+INFO         |      Ok: System requirements to run avd: `Pixel` are met
+INFO         | Loading snapshot 'default_boot'...
+WARNING      | Client not connected yet. Ignoring message!
+WARNING      | Client not connected yet. Ignoring message!
+WARNING      | Client not connected yet. Ignoring message!
+WARNING      | Unknown XR viewport mode requested: 0, ignored.
+
+INFO         | Successfully loaded snapshot 'default_boot'
+ERROR        | Failed to find ColorBuffer:0
+INFO         | Activated packet streamer for bluetooth emulation
+INFO         | Wait for emulator (pid 90315) 20 seconds to shutdown gracefully before kill;you can set environment variable ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL(in seconds) to change the default value (20 seconds)
+
+INFO         | Wait for emulator (pid 90315) 20 seconds to shutdown gracefully before kill;you can set environment variable ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL(in seconds) to change the default value (20 seconds)
+
+INFO         | Saving with gfxstream=1
+ERROR        | Failed to restore previous context: 12297
+INFO         | Android emulator version 35.5.2.0 (build_id 13003482) (CL:N/A)
+INFO         | Graphics backend: gfxstream
+INFO         | Found systemPath /nix/store/hzl1xnx8w48is86566s446mq7zm7dk80-androidsdk/libexec/android-sdk/system-images/android-35/google_apis_playstore/arm64-v8a/
+INFO         | Increasing RAM size to 2048MB
+INFO         | Checking system compatibility:
+INFO         |   Checking: hasSufficientDiskSpace
+INFO         |      Ok: Disk space requirements to run avd: `Pixel` are met
+INFO         |   Checking: hasSufficientHwGpu
+INFO         |      Ok: Hardware GPU requirements to run avd: `Pixel` are passed
+INFO         |   Checking: hasSufficientSystem
+INFO         |      Ok: System requirements to run avd: `Pixel` are met
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_btn_xr_environment_living_room_day_clicked() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_btn_xr_environment_living_room_night_clicked() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_new_posture_requested(int) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_posture_selection_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_new_resizable_requested(PresetEmulatorSizeType) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_resizable_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_xr_environment_mode_changed(int) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_xr_environment_mode_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_xr_input_mode_changed(int) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_xr_input_mode_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_sleep_timer_done() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_unfold_timer_done() (:0, )
+INFO         | Storing crashdata in: /tmp/android-amiceli/emu-crash-35.5.2.db, detection is enabled for process: 90793
+INFO         | Guest Driver: Auto (ext controls)
+library_mode host gpu mode host
+INFO         | Initializing hardware OpenGLES emulation support
+I0721 21:31:56.854262 5065f00 opengles.cpp:285] android_startOpenglesRenderer: gpu info
+I0721 21:31:56.854272 5065f00 opengles.cpp:286] 
+INFO         | HealthMonitor disabled.
+INFO         | initIcdPaths: ICD set to 'swiftshader', using Swiftshader ICD
+INFO         | Setting ICD filenames for the loader = /nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/vk_swiftshader_icd.json:/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/vk_swiftshader_icd.json
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib]
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] (posix): begin
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] (posix,darwin): call dlopen
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] (posix,darwin): failed, try again with [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib]
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] failed (posix). dlerror: []
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib]
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib] (posix): begin
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib] (posix,darwin): call dlopen
+
+INFO         | Added library: /nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib
+INFO         | Selecting Vulkan device: SwiftShader Device (LLVM 10.0.0), Version: 1.2.0
+INFO         | Supports id properties, got a vulkan device UUID
+INFO         | SharedLibrary::open for [/System/Library/Frameworks/OpenGL.framework/OpenGL]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [/System/Library/Frameworks/OpenGL.framework/OpenGL] (posix): begin
+
+INFO         | SharedLibrary::open for [/System/Library/Frameworks/OpenGL.framework/OpenGL] (posix,darwin): call dlopen
+
+INFO         | SharedLibrary::open for [libshadertranslator.dylib]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [libshadertranslator.dylib] (posix): begin
+
+INFO         | SharedLibrary::open for [libshadertranslator.dylib] (posix,darwin): call dlopen
+
+INFO         | Initializing VkEmulation features:
+INFO         |     glInteropSupported: false
+INFO         |     useDeferredCommands: true
+INFO         |     createResourceWithRequirements: true
+INFO         |     useVulkanComposition: false
+INFO         |     useVulkanNativeSwapchain: false
+INFO         |     enable guestRenderDoc: false
+INFO         |     ASTC LDR emulation mode: 2
+INFO         |     enable ETC2 emulation: true
+INFO         |     enable Ycbcr emulation: false
+INFO         |     guestVulkanOnly: false
+INFO         |     useDedicatedAllocations: false
+INFO         | Graphics Adapter Vendor Google (Apple)
+INFO         | Graphics Adapter Android Emulator OpenGL ES Translator (Apple M3)
+INFO         | Graphics API Version OpenGL ES 3.0 (4.1 Metal - 89.4)
+INFO         | Graphics API Extensions GL_OES_EGL_sync GL_OES_EGL_image GL_OES_EGL_image_external GL_OES_depth24 GL_OES_depth32 GL_OES_element_index_uint GL_OES_texture_float GL_OES_texture_float_linear GL_OES_compressed_paletted_texture GL_OES_compressed_ETC1_RGB8_texture GL_OES_depth_texture GL_OES_texture_npot GL_OES_rgb8_rgba8 GL_EXT_color_buffer_float GL_EXT_color_buffer_half_float GL_EXT_texture_format_BGRA8888 GL_APPLE_texture_format_BGRA8888 
+INFO         | Graphics Device Extensions N/A
+INFO         | Sending adb public key [QAAAAIVjas+z4g2zV2PZy4jj+mLM9NhvmJz2yjVCQ4y+i5AkE1yQ1Qb99SEdLqSFyYxr1XwHDo20Y7HphQP2r1Yp+DE6j8cn6TUVj/0vvBLIR+z6/yW6JrYpRJoQCRfGShHWx1t3z2yHayK85lxxjBfLZPohjJhIwBOH93e/dkHzEOIkSM2c2dN+O5hX9gBXNFItznXZqfSTV+4bSknrRho8TXlxwCxCswk4UkXrbCsCdQmrHfFHVOAftL4f0QYJML6JoeHCQKGLqejgb1839FDDdEwDp9WXp9lCzCqW5/hLz/s8hnC/93vY0hC+Dh6K31rLihekJ/YfnlCOSefCErb55kh19deffD/sXhLBcfWnkB49jhvDf+HWSGbjQYUPMbBd+Rl4YGo2Fa0rJJ7Oolo36InMudIrCd7gojXYtj9vO6XPA9I93ftQgZMWYoFP3tbQRpWDnfBDT3JG5PZNFt3nV42OQSKB3O9MFJ/Y72Ev9mWxAx6vd1HYq+pT9YSR+K1znApOM+vVydeAczfXTUxknAGJWCExpPLKtLF268XCudhDhWXNBjxDDIteZcCR4gssOn87tHnf+fdrOZPqb98NqUd/Fs+bo0gRIVp3t0neF8KEdiYATfAKCVrjchziA66pSSMvHbRCnf+pn1Z9d+8mAjvLzRW51KipNbP40f8i9KUMGTIRPgEAAQA= amiceli@unknown]
+INFO         | Userspace boot properties:
+INFO         |   androidboot.boot_devices=a003600.virtio_mmio
+INFO         |   androidboot.dalvik.vm.heapsize=512m
+INFO         |   androidboot.debug.hwui.renderer=skiagl
+INFO         |   androidboot.hardware=ranchu
+INFO         |   androidboot.hardware.gltransport=pipe
+INFO         |   androidboot.hardware.vulkan=ranchu
+INFO         |   androidboot.logcat=*:V
+INFO         |   androidboot.opengles.version=196608
+INFO         |   androidboot.qemu=1
+INFO         |   androidboot.qemu.adb.pubkey=QAAAAIVjas+z4g2zV2PZy4jj+mLM9NhvmJz2yjVCQ4y+i5AkE1yQ1Qb99SEdLqSFyYxr1XwHDo20Y7HphQP2r1Yp+DE6j8cn6TUVj/0vvBLIR+z6/yW6JrYpRJoQCRfGShHWx1t3z2yHayK85lxxjBfLZPohjJhIwBOH93e/dkHzEOIkSM2c2dN+O5hX9gBXNFItznXZqfSTV+4bSknrRho8TXlxwCxCswk4UkXrbCsCdQmrHfFHVOAftL4f0QYJML6JoeHCQKGLqejgb1839FDDdEwDp9WXp9lCzCqW5/hLz/s8hnC/93vY0hC+Dh6K31rLihekJ/YfnlCOSefCErb55kh19deffD/sXhLBcfWnkB49jhvDf+HWSGbjQYUPMbBd+Rl4YGo2Fa0rJJ7Oolo36InMudIrCd7gojXYtj9vO6XPA9I93ftQgZMWYoFP3tbQRpWDnfBDT3JG5PZNFt3nV42OQSKB3O9MFJ/Y72Ev9mWxAx6vd1HYq+pT9YSR+K1znApOM+vVydeAczfXTUxknAGJWCExpPLKtLF268XCudhDhWXNBjxDDIteZcCR4gssOn87tHnf+fdrOZPqb98NqUd/Fs+bo0gRIVp3t0neF8KEdiYATfAKCVrjchziA66pSSMvHbRCnf+pn1Z9d+8mAjvLzRW51KipNbP40f8i9KUMGTIRPgEAAQA= amiceli@unknown
+INFO         |   androidboot.qemu.avd_name=Pixel
+INFO         |   androidboot.qemu.camera_hq_edge_processing=0
+INFO         |   androidboot.qemu.camera_protocol_ver=1
+INFO         |   androidboot.qemu.cpuvulkan.version=4202496
+INFO         |   androidboot.qemu.gltransport.drawFlushInterval=800
+INFO         |   androidboot.qemu.gltransport.name=pipe
+INFO         |   androidboot.qemu.hwcodec.avcdec=2
+INFO         |   androidboot.qemu.hwcodec.hevcdec=2
+INFO         |   androidboot.qemu.hwcodec.vpxdec=2
+INFO         |   androidboot.qemu.settings.system.screen_off_timeout=2147483647
+INFO         |   androidboot.qemu.virtiowifi=1
+INFO         |   androidboot.qemu.vsync=60
+INFO         |   androidboot.serialno=EMULATOR35X5X2X0
+INFO         |   androidboot.vbmeta.digest=017677f8986b0ac374dfb8d37fd142d50a77bda4a20142da493c5a4c3b962b87
+INFO         |   androidboot.vbmeta.hash_alg=sha256
+INFO         |   androidboot.vbmeta.size=6720
+INFO         |   androidboot.veritymode=enforcing
+INFO         | Monitoring duration of emulator setup.
+WARNING      | The emulator now requires a signed jwt token for gRPC access! Use the -grpc flag if you really want an open unprotected grpc port
+INFO         | Using security allow list from: /nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib/emulator_access.json
+WARNING      | *** Basic token auth should only be used by android-studio ***
+INFO         | The active JSON Web Key Sets can be found here: /Users/amiceli/Library/Caches/TemporaryItems/avd/running/90793/jwks/ebf621b1-4747-43c0-bc6a-bebb2caaef59/active.jwk
+INFO         | Scanning /Users/amiceli/Library/Caches/TemporaryItems/avd/running/90793/jwks/ebf621b1-4747-43c0-bc6a-bebb2caaef59 for jwk keys.
+INFO         | Started GRPC server at 127.0.0.1:8554, security: Local, auth: +token
+INFO         | Advertising in: /Users/amiceli/Library/Caches/TemporaryItems/avd/running/pid_90793.ini
+INFO         | Setting display: 0 configuration to: 320x640, dpi: 160x160 
+INFO         | setDisplayActiveConfig 0
+INFO         | Checking system compatibility:
+INFO         |   Checking: hasSufficientDiskSpace
+INFO         |      Ok: Disk space requirements to run avd: `Pixel` are met
+INFO         |   Checking: hasSufficientHwGpu
+INFO         |      Ok: Hardware GPU requirements to run avd: `Pixel` are passed
+INFO         |   Checking: hasSufficientSystem
+INFO         |      Ok: System requirements to run avd: `Pixel` are met
+INFO         | Loading snapshot 'default_boot'...
+WARNING      | Client not connected yet. Ignoring message!
+WARNING      | Client not connected yet. Ignoring message!
+WARNING      | Client not connected yet. Ignoring message!
+WARNING      | Unknown XR viewport mode requested: 0, ignored.
+
+INFO         | Successfully loaded snapshot 'default_boot'
+ERROR        | Failed to find ColorBuffer:0
+INFO         | Activated packet streamer for bluetooth emulation
+ERROR        | Failed to find ColorBuffer:0
+ERROR        | Failed to find ColorBuffer:0
+INFO         | Warning: skipping QEventPoint(id=1 ts=0 pos=0,0 scn=323.985,705.145 gbl=323.985,705.145 Released ellipse=(1x1 ∡ 0) vel=0,0 press=-323.985,-705.145 last=-323.985,-705.145 Δ 323.985,705.145) : no target window (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_rgbcSensorValueWidget_valueChanged() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_posture_valueChanged(int) (:0, )
+INFO         | AVD supportsNativeGLES=1, supportsGuestAngle=1
+INFO         | Warning: skipping QEventPoint(id=1 ts=0 pos=0,0 scn=266.505,329.13 gbl=266.505,329.13 Released ellipse=(1x1 ∡ 0) vel=0,0 press=-266.505,-329.13 last=-266.505,-329.13 Δ 266.505,329.13) : no target window (:0, )
+INFO         | Wait for emulator (pid 90793) 20 seconds to shutdown gracefully before kill;you can set environment variable ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL(in seconds) to change the default value (20 seconds)
+
+INFO         | Saving with gfxstream=1
+INFO         | Android emulator version 35.5.2.0 (build_id 13003482) (CL:N/A)
+INFO         | Graphics backend: gfxstream
+INFO         | Found systemPath /nix/store/hzl1xnx8w48is86566s446mq7zm7dk80-androidsdk/libexec/android-sdk/system-images/android-35/google_apis_playstore/arm64-v8a/
+INFO         | Increasing RAM size to 2048MB
+INFO         | Checking system compatibility:
+INFO         |   Checking: hasSufficientDiskSpace
+INFO         |      Ok: Disk space requirements to run avd: `Pixel` are met
+INFO         |   Checking: hasSufficientHwGpu
+INFO         |      Ok: Hardware GPU requirements to run avd: `Pixel` are passed
+INFO         |   Checking: hasSufficientSystem
+INFO         |      Ok: System requirements to run avd: `Pixel` are met
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_btn_xr_environment_living_room_day_clicked() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_btn_xr_environment_living_room_night_clicked() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_new_posture_requested(int) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_posture_selection_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_new_resizable_requested(PresetEmulatorSizeType) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_resizable_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_xr_environment_mode_changed(int) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_xr_environment_mode_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_xr_input_mode_changed(int) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_xr_input_mode_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_sleep_timer_done() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_unfold_timer_done() (:0, )
+INFO         | Storing crashdata in: /tmp/android-amiceli/emu-crash-35.5.2.db, detection is enabled for process: 91440
+INFO         | Guest Driver: Auto (ext controls)
+library_mode host gpu mode host
+INFO         | Initializing hardware OpenGLES emulation support
+I0721 21:45:16.303370 5065f00 opengles.cpp:285] android_startOpenglesRenderer: gpu info
+I0721 21:45:16.303379 5065f00 opengles.cpp:286] 
+INFO         | HealthMonitor disabled.
+INFO         | initIcdPaths: ICD set to 'swiftshader', using Swiftshader ICD
+INFO         | Setting ICD filenames for the loader = /nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/vk_swiftshader_icd.json:/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/vk_swiftshader_icd.json
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib]
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] (posix): begin
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] (posix,darwin): call dlopen
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] (posix,darwin): failed, try again with [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib]
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] failed (posix). dlerror: []
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib]
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib] (posix): begin
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib] (posix,darwin): call dlopen
+
+INFO         | Added library: /nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib
+INFO         | Selecting Vulkan device: SwiftShader Device (LLVM 10.0.0), Version: 1.2.0
+INFO         | Supports id properties, got a vulkan device UUID
+INFO         | SharedLibrary::open for [/System/Library/Frameworks/OpenGL.framework/OpenGL]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [/System/Library/Frameworks/OpenGL.framework/OpenGL] (posix): begin
+
+INFO         | SharedLibrary::open for [/System/Library/Frameworks/OpenGL.framework/OpenGL] (posix,darwin): call dlopen
+
+INFO         | SharedLibrary::open for [libshadertranslator.dylib]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [libshadertranslator.dylib] (posix): begin
+
+INFO         | SharedLibrary::open for [libshadertranslator.dylib] (posix,darwin): call dlopen
+
+INFO         | Initializing VkEmulation features:
+INFO         |     glInteropSupported: false
+INFO         |     useDeferredCommands: true
+INFO         |     createResourceWithRequirements: true
+INFO         |     useVulkanComposition: false
+INFO         |     useVulkanNativeSwapchain: false
+INFO         |     enable guestRenderDoc: false
+INFO         |     ASTC LDR emulation mode: 2
+INFO         |     enable ETC2 emulation: true
+INFO         |     enable Ycbcr emulation: false
+INFO         |     guestVulkanOnly: false
+INFO         |     useDedicatedAllocations: false
+INFO         | Graphics Adapter Vendor Google (Apple)
+INFO         | Graphics Adapter Android Emulator OpenGL ES Translator (Apple M3)
+INFO         | Graphics API Version OpenGL ES 3.0 (4.1 Metal - 89.4)
+INFO         | Graphics API Extensions GL_OES_EGL_sync GL_OES_EGL_image GL_OES_EGL_image_external GL_OES_depth24 GL_OES_depth32 GL_OES_element_index_uint GL_OES_texture_float GL_OES_texture_float_linear GL_OES_compressed_paletted_texture GL_OES_compressed_ETC1_RGB8_texture GL_OES_depth_texture GL_OES_texture_npot GL_OES_rgb8_rgba8 GL_EXT_color_buffer_float GL_EXT_color_buffer_half_float GL_EXT_texture_format_BGRA8888 GL_APPLE_texture_format_BGRA8888 
+INFO         | Graphics Device Extensions N/A
+INFO         | Sending adb public key [QAAAAIVjas+z4g2zV2PZy4jj+mLM9NhvmJz2yjVCQ4y+i5AkE1yQ1Qb99SEdLqSFyYxr1XwHDo20Y7HphQP2r1Yp+DE6j8cn6TUVj/0vvBLIR+z6/yW6JrYpRJoQCRfGShHWx1t3z2yHayK85lxxjBfLZPohjJhIwBOH93e/dkHzEOIkSM2c2dN+O5hX9gBXNFItznXZqfSTV+4bSknrRho8TXlxwCxCswk4UkXrbCsCdQmrHfFHVOAftL4f0QYJML6JoeHCQKGLqejgb1839FDDdEwDp9WXp9lCzCqW5/hLz/s8hnC/93vY0hC+Dh6K31rLihekJ/YfnlCOSefCErb55kh19deffD/sXhLBcfWnkB49jhvDf+HWSGbjQYUPMbBd+Rl4YGo2Fa0rJJ7Oolo36InMudIrCd7gojXYtj9vO6XPA9I93ftQgZMWYoFP3tbQRpWDnfBDT3JG5PZNFt3nV42OQSKB3O9MFJ/Y72Ev9mWxAx6vd1HYq+pT9YSR+K1znApOM+vVydeAczfXTUxknAGJWCExpPLKtLF268XCudhDhWXNBjxDDIteZcCR4gssOn87tHnf+fdrOZPqb98NqUd/Fs+bo0gRIVp3t0neF8KEdiYATfAKCVrjchziA66pSSMvHbRCnf+pn1Z9d+8mAjvLzRW51KipNbP40f8i9KUMGTIRPgEAAQA= amiceli@unknown]
+INFO         | Userspace boot properties:
+INFO         |   androidboot.boot_devices=a003600.virtio_mmio
+INFO         |   androidboot.dalvik.vm.heapsize=512m
+INFO         |   androidboot.debug.hwui.renderer=skiagl
+INFO         |   androidboot.hardware=ranchu
+INFO         |   androidboot.hardware.gltransport=pipe
+INFO         |   androidboot.hardware.vulkan=ranchu
+INFO         |   androidboot.logcat=*:V
+INFO         |   androidboot.opengles.version=196608
+INFO         |   androidboot.qemu=1
+INFO         |   androidboot.qemu.adb.pubkey=QAAAAIVjas+z4g2zV2PZy4jj+mLM9NhvmJz2yjVCQ4y+i5AkE1yQ1Qb99SEdLqSFyYxr1XwHDo20Y7HphQP2r1Yp+DE6j8cn6TUVj/0vvBLIR+z6/yW6JrYpRJoQCRfGShHWx1t3z2yHayK85lxxjBfLZPohjJhIwBOH93e/dkHzEOIkSM2c2dN+O5hX9gBXNFItznXZqfSTV+4bSknrRho8TXlxwCxCswk4UkXrbCsCdQmrHfFHVOAftL4f0QYJML6JoeHCQKGLqejgb1839FDDdEwDp9WXp9lCzCqW5/hLz/s8hnC/93vY0hC+Dh6K31rLihekJ/YfnlCOSefCErb55kh19deffD/sXhLBcfWnkB49jhvDf+HWSGbjQYUPMbBd+Rl4YGo2Fa0rJJ7Oolo36InMudIrCd7gojXYtj9vO6XPA9I93ftQgZMWYoFP3tbQRpWDnfBDT3JG5PZNFt3nV42OQSKB3O9MFJ/Y72Ev9mWxAx6vd1HYq+pT9YSR+K1znApOM+vVydeAczfXTUxknAGJWCExpPLKtLF268XCudhDhWXNBjxDDIteZcCR4gssOn87tHnf+fdrOZPqb98NqUd/Fs+bo0gRIVp3t0neF8KEdiYATfAKCVrjchziA66pSSMvHbRCnf+pn1Z9d+8mAjvLzRW51KipNbP40f8i9KUMGTIRPgEAAQA= amiceli@unknown
+INFO         |   androidboot.qemu.avd_name=Pixel
+INFO         |   androidboot.qemu.camera_hq_edge_processing=0
+INFO         |   androidboot.qemu.camera_protocol_ver=1
+INFO         |   androidboot.qemu.cpuvulkan.version=4202496
+INFO         |   androidboot.qemu.gltransport.drawFlushInterval=800
+INFO         |   androidboot.qemu.gltransport.name=pipe
+INFO         |   androidboot.qemu.hwcodec.avcdec=2
+INFO         |   androidboot.qemu.hwcodec.hevcdec=2
+INFO         |   androidboot.qemu.hwcodec.vpxdec=2
+INFO         |   androidboot.qemu.settings.system.screen_off_timeout=2147483647
+INFO         |   androidboot.qemu.virtiowifi=1
+INFO         |   androidboot.qemu.vsync=60
+INFO         |   androidboot.serialno=EMULATOR35X5X2X0
+INFO         |   androidboot.vbmeta.digest=017677f8986b0ac374dfb8d37fd142d50a77bda4a20142da493c5a4c3b962b87
+INFO         |   androidboot.vbmeta.hash_alg=sha256
+INFO         |   androidboot.vbmeta.size=6720
+INFO         |   androidboot.veritymode=enforcing
+INFO         | Monitoring duration of emulator setup.
+WARNING      | The emulator now requires a signed jwt token for gRPC access! Use the -grpc flag if you really want an open unprotected grpc port
+INFO         | Using security allow list from: /nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib/emulator_access.json
+WARNING      | *** Basic token auth should only be used by android-studio ***
+INFO         | The active JSON Web Key Sets can be found here: /Users/amiceli/Library/Caches/TemporaryItems/avd/running/91440/jwks/be857e70-72af-414d-81b8-da214a7e0e57/active.jwk
+INFO         | Scanning /Users/amiceli/Library/Caches/TemporaryItems/avd/running/91440/jwks/be857e70-72af-414d-81b8-da214a7e0e57 for jwk keys.
+INFO         | Started GRPC server at 127.0.0.1:8554, security: Local, auth: +token
+INFO         | Advertising in: /Users/amiceli/Library/Caches/TemporaryItems/avd/running/pid_91440.ini
+INFO         | Setting display: 0 configuration to: 1080x2400, dpi: 420x420 
+INFO         | setDisplayActiveConfig 0
+INFO         | Checking system compatibility:
+INFO         |   Checking: hasSufficientDiskSpace
+INFO         |      Ok: Disk space requirements to run avd: `Pixel` are met
+INFO         |   Checking: hasSufficientHwGpu
+INFO         |      Ok: Hardware GPU requirements to run avd: `Pixel` are passed
+INFO         |   Checking: hasSufficientSystem
+INFO         |      Ok: System requirements to run avd: `Pixel` are met
+INFO         | Loading snapshot 'default_boot'...
+WARNING      | Device 'encrypt' does not have the requested snapshot 'default_boot'
+
+WARNING      | Failed to load snapshot 'default_boot'
+INFO         | Activated packet streamer for bluetooth emulation
+INFO         | Warning: skipping QEventPoint(id=1 ts=0 pos=0,0 scn=450.646,215.822 gbl=450.646,215.822 Released ellipse=(1x1 ∡ 0) vel=0,0 press=-450.646,-215.822 last=-450.646,-215.822 Δ 450.646,215.822) : no target window (:0, )
+INFO         | Boot completed in 14447 ms
+INFO         | Increasing screen off timeout, logcat buffer size to 2M.
+INFO         | Warning: skipping QEventPoint(id=1 ts=0 pos=0,0 scn=316.173,850.477 gbl=316.173,850.477 Released ellipse=(1x1 ∡ 0) vel=0,0 press=-316.173,-850.477 last=-316.173,-850.477 Δ 316.173,850.477) : no target window (:0, )
+INFO         | Warning: skipping QEventPoint(id=1 ts=0 pos=0,0 scn=479.313,361.24 gbl=479.313,361.24 Released ellipse=(1x1 ∡ 0) vel=0,0 press=-479.313,-361.24 last=-479.313,-361.24 Δ 479.313,361.24) : no target window (:0, )
+INFO         | Warning: skipping QEventPoint(id=1 ts=0 pos=0,0 scn=408.77,826.649 gbl=408.77,826.649 Released ellipse=(1x1 ∡ 0) vel=0,0 press=-408.77,-826.649 last=-408.77,-826.649 Δ 408.77,826.649) : no target window (:0, )
+INFO         | Warning: skipping QEventPoint(id=1 ts=0 pos=0,0 scn=481.211,452.032 gbl=481.211,452.032 Released ellipse=(1x1 ∡ 0) vel=0,0 press=-481.211,-452.032 last=-481.211,-452.032 Δ 481.211,452.032) : no target window (:0, )
+INFO         | Wait for emulator (pid 91440) 20 seconds to shutdown gracefully before kill;you can set environment variable ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL(in seconds) to change the default value (20 seconds)
+
+INFO         | Saving with gfxstream=1
+ERROR        | Failed to restore previous context: 12297
+INFO         | Android emulator version 35.5.2.0 (build_id 13003482) (CL:N/A)
+INFO         | Graphics backend: gfxstream
+INFO         | Found systemPath /nix/store/hzl1xnx8w48is86566s446mq7zm7dk80-androidsdk/libexec/android-sdk/system-images/android-35/google_apis_playstore/arm64-v8a/
+INFO         | Increasing RAM size to 2048MB
+INFO         | Checking system compatibility:
+INFO         |   Checking: hasSufficientDiskSpace
+INFO         |      Ok: Disk space requirements to run avd: `Pixel` are met
+INFO         |   Checking: hasSufficientHwGpu
+INFO         |      Ok: Hardware GPU requirements to run avd: `Pixel` are passed
+INFO         |   Checking: hasSufficientSystem
+INFO         |      Ok: System requirements to run avd: `Pixel` are met
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_btn_xr_environment_living_room_day_clicked() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_btn_xr_environment_living_room_night_clicked() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_new_posture_requested(int) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_posture_selection_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_new_resizable_requested(PresetEmulatorSizeType) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_resizable_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_xr_environment_mode_changed(int) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_xr_environment_mode_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_xr_input_mode_changed(int) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_xr_input_mode_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_sleep_timer_done() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_unfold_timer_done() (:0, )
+INFO         | Storing crashdata in: /tmp/android-amiceli/emu-crash-35.5.2.db, detection is enabled for process: 92124
+INFO         | Guest Driver: Auto (ext controls)
+library_mode host gpu mode host
+INFO         | Initializing hardware OpenGLES emulation support
+I0721 21:48:28.215608 5065f00 opengles.cpp:285] android_startOpenglesRenderer: gpu info
+I0721 21:48:28.215620 5065f00 opengles.cpp:286] 
+INFO         | HealthMonitor disabled.
+INFO         | initIcdPaths: ICD set to 'swiftshader', using Swiftshader ICD
+INFO         | Setting ICD filenames for the loader = /nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/vk_swiftshader_icd.json:/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/vk_swiftshader_icd.json
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib]
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] (posix): begin
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] (posix,darwin): call dlopen
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] (posix,darwin): failed, try again with [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib]
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] failed (posix). dlerror: []
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib]
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib] (posix): begin
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib] (posix,darwin): call dlopen
+
+INFO         | Added library: /nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib
+INFO         | Selecting Vulkan device: SwiftShader Device (LLVM 10.0.0), Version: 1.2.0
+INFO         | Supports id properties, got a vulkan device UUID
+INFO         | SharedLibrary::open for [/System/Library/Frameworks/OpenGL.framework/OpenGL]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [/System/Library/Frameworks/OpenGL.framework/OpenGL] (posix): begin
+
+INFO         | SharedLibrary::open for [/System/Library/Frameworks/OpenGL.framework/OpenGL] (posix,darwin): call dlopen
+
+INFO         | SharedLibrary::open for [libshadertranslator.dylib]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [libshadertranslator.dylib] (posix): begin
+
+INFO         | SharedLibrary::open for [libshadertranslator.dylib] (posix,darwin): call dlopen
+
+INFO         | Initializing VkEmulation features:
+INFO         |     glInteropSupported: false
+INFO         |     useDeferredCommands: true
+INFO         |     createResourceWithRequirements: true
+INFO         |     useVulkanComposition: false
+INFO         |     useVulkanNativeSwapchain: false
+INFO         |     enable guestRenderDoc: false
+INFO         |     ASTC LDR emulation mode: 2
+INFO         |     enable ETC2 emulation: true
+INFO         |     enable Ycbcr emulation: false
+INFO         |     guestVulkanOnly: false
+INFO         |     useDedicatedAllocations: false
+INFO         | Graphics Adapter Vendor Google (Apple)
+INFO         | Graphics Adapter Android Emulator OpenGL ES Translator (Apple M3)
+INFO         | Graphics API Version OpenGL ES 3.0 (4.1 Metal - 89.4)
+INFO         | Graphics API Extensions GL_OES_EGL_sync GL_OES_EGL_image GL_OES_EGL_image_external GL_OES_depth24 GL_OES_depth32 GL_OES_element_index_uint GL_OES_texture_float GL_OES_texture_float_linear GL_OES_compressed_paletted_texture GL_OES_compressed_ETC1_RGB8_texture GL_OES_depth_texture GL_OES_texture_npot GL_OES_rgb8_rgba8 GL_EXT_color_buffer_float GL_EXT_color_buffer_half_float GL_EXT_texture_format_BGRA8888 GL_APPLE_texture_format_BGRA8888 
+INFO         | Graphics Device Extensions N/A
+INFO         | Sending adb public key [QAAAAIVjas+z4g2zV2PZy4jj+mLM9NhvmJz2yjVCQ4y+i5AkE1yQ1Qb99SEdLqSFyYxr1XwHDo20Y7HphQP2r1Yp+DE6j8cn6TUVj/0vvBLIR+z6/yW6JrYpRJoQCRfGShHWx1t3z2yHayK85lxxjBfLZPohjJhIwBOH93e/dkHzEOIkSM2c2dN+O5hX9gBXNFItznXZqfSTV+4bSknrRho8TXlxwCxCswk4UkXrbCsCdQmrHfFHVOAftL4f0QYJML6JoeHCQKGLqejgb1839FDDdEwDp9WXp9lCzCqW5/hLz/s8hnC/93vY0hC+Dh6K31rLihekJ/YfnlCOSefCErb55kh19deffD/sXhLBcfWnkB49jhvDf+HWSGbjQYUPMbBd+Rl4YGo2Fa0rJJ7Oolo36InMudIrCd7gojXYtj9vO6XPA9I93ftQgZMWYoFP3tbQRpWDnfBDT3JG5PZNFt3nV42OQSKB3O9MFJ/Y72Ev9mWxAx6vd1HYq+pT9YSR+K1znApOM+vVydeAczfXTUxknAGJWCExpPLKtLF268XCudhDhWXNBjxDDIteZcCR4gssOn87tHnf+fdrOZPqb98NqUd/Fs+bo0gRIVp3t0neF8KEdiYATfAKCVrjchziA66pSSMvHbRCnf+pn1Z9d+8mAjvLzRW51KipNbP40f8i9KUMGTIRPgEAAQA= amiceli@unknown]
+INFO         | Userspace boot properties:
+INFO         |   androidboot.boot_devices=a003600.virtio_mmio
+INFO         |   androidboot.dalvik.vm.heapsize=512m
+INFO         |   androidboot.debug.hwui.renderer=skiagl
+INFO         |   androidboot.hardware=ranchu
+INFO         |   androidboot.hardware.gltransport=pipe
+INFO         |   androidboot.hardware.vulkan=ranchu
+INFO         |   androidboot.logcat=*:V
+INFO         |   androidboot.opengles.version=196608
+INFO         |   androidboot.qemu=1
+INFO         |   androidboot.qemu.adb.pubkey=QAAAAIVjas+z4g2zV2PZy4jj+mLM9NhvmJz2yjVCQ4y+i5AkE1yQ1Qb99SEdLqSFyYxr1XwHDo20Y7HphQP2r1Yp+DE6j8cn6TUVj/0vvBLIR+z6/yW6JrYpRJoQCRfGShHWx1t3z2yHayK85lxxjBfLZPohjJhIwBOH93e/dkHzEOIkSM2c2dN+O5hX9gBXNFItznXZqfSTV+4bSknrRho8TXlxwCxCswk4UkXrbCsCdQmrHfFHVOAftL4f0QYJML6JoeHCQKGLqejgb1839FDDdEwDp9WXp9lCzCqW5/hLz/s8hnC/93vY0hC+Dh6K31rLihekJ/YfnlCOSefCErb55kh19deffD/sXhLBcfWnkB49jhvDf+HWSGbjQYUPMbBd+Rl4YGo2Fa0rJJ7Oolo36InMudIrCd7gojXYtj9vO6XPA9I93ftQgZMWYoFP3tbQRpWDnfBDT3JG5PZNFt3nV42OQSKB3O9MFJ/Y72Ev9mWxAx6vd1HYq+pT9YSR+K1znApOM+vVydeAczfXTUxknAGJWCExpPLKtLF268XCudhDhWXNBjxDDIteZcCR4gssOn87tHnf+fdrOZPqb98NqUd/Fs+bo0gRIVp3t0neF8KEdiYATfAKCVrjchziA66pSSMvHbRCnf+pn1Z9d+8mAjvLzRW51KipNbP40f8i9KUMGTIRPgEAAQA= amiceli@unknown
+INFO         |   androidboot.qemu.avd_name=Pixel
+INFO         |   androidboot.qemu.camera_hq_edge_processing=0
+INFO         |   androidboot.qemu.camera_protocol_ver=1
+INFO         |   androidboot.qemu.cpuvulkan.version=4202496
+INFO         |   androidboot.qemu.gltransport.drawFlushInterval=800
+INFO         |   androidboot.qemu.gltransport.name=pipe
+INFO         |   androidboot.qemu.hwcodec.avcdec=2
+INFO         |   androidboot.qemu.hwcodec.hevcdec=2
+INFO         |   androidboot.qemu.hwcodec.vpxdec=2
+INFO         |   androidboot.qemu.settings.system.screen_off_timeout=2147483647
+INFO         |   androidboot.qemu.virtiowifi=1
+INFO         |   androidboot.qemu.vsync=60
+INFO         |   androidboot.serialno=EMULATOR35X5X2X0
+INFO         |   androidboot.vbmeta.digest=017677f8986b0ac374dfb8d37fd142d50a77bda4a20142da493c5a4c3b962b87
+INFO         |   androidboot.vbmeta.hash_alg=sha256
+INFO         |   androidboot.vbmeta.size=6720
+INFO         |   androidboot.veritymode=enforcing
+INFO         | Monitoring duration of emulator setup.
+WARNING      | The emulator now requires a signed jwt token for gRPC access! Use the -grpc flag if you really want an open unprotected grpc port
+INFO         | Using security allow list from: /nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib/emulator_access.json
+WARNING      | *** Basic token auth should only be used by android-studio ***
+INFO         | The active JSON Web Key Sets can be found here: /Users/amiceli/Library/Caches/TemporaryItems/avd/running/92124/jwks/12b67034-122b-4f32-a0af-95c39551fde6/active.jwk
+INFO         | Scanning /Users/amiceli/Library/Caches/TemporaryItems/avd/running/92124/jwks/12b67034-122b-4f32-a0af-95c39551fde6 for jwk keys.
+INFO         | Started GRPC server at 127.0.0.1:8554, security: Local, auth: +token
+INFO         | Advertising in: /Users/amiceli/Library/Caches/TemporaryItems/avd/running/pid_92124.ini
+INFO         | Setting display: 0 configuration to: 1080x2400, dpi: 420x420 
+INFO         | setDisplayActiveConfig 0
+INFO         | Checking system compatibility:
+INFO         |   Checking: hasSufficientDiskSpace
+INFO         |      Ok: Disk space requirements to run avd: `Pixel` are met
+INFO         |   Checking: hasSufficientHwGpu
+INFO         |      Ok: Hardware GPU requirements to run avd: `Pixel` are passed
+INFO         |   Checking: hasSufficientSystem
+INFO         |      Ok: System requirements to run avd: `Pixel` are met
+INFO         | Loading snapshot 'default_boot'...
+WARNING      | Device 'encrypt' does not have the requested snapshot 'default_boot'
+
+WARNING      | Failed to load snapshot 'default_boot'
+INFO         | Activated packet streamer for bluetooth emulation
+INFO         | Boot completed in 14292 ms
+INFO         | Increasing screen off timeout, logcat buffer size to 2M.
+INFO         | Warning: skipping QEventPoint(id=1 ts=0 pos=0,0 scn=233.502,187.064 gbl=233.502,187.064 Released ellipse=(1x1 ∡ 0) vel=0,0 press=-233.502,-187.064 last=-233.502,-187.064 Δ 233.502,187.064) : no target window (:0, )
+INFO         | Warning: skipping QEventPoint(id=1 ts=0 pos=0,0 scn=100.663,159.955 gbl=100.663,159.955 Released ellipse=(1x1 ∡ 0) vel=0,0 press=-100.663,-159.955 last=-100.663,-159.955 Δ 100.663,159.955) : no target window (:0, )
+INFO         | Wait for emulator (pid 92124) 20 seconds to shutdown gracefully before kill;you can set environment variable ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL(in seconds) to change the default value (20 seconds)
+
+INFO         | Saving with gfxstream=1
+ERROR        | Failed to restore previous context: 12297
+INFO         | Android emulator version 35.5.2.0 (build_id 13003482) (CL:N/A)
+INFO         | Graphics backend: gfxstream
+INFO         | Found systemPath /nix/store/hzl1xnx8w48is86566s446mq7zm7dk80-androidsdk/libexec/android-sdk/system-images/android-35/google_apis_playstore/arm64-v8a/
+INFO         | Increasing RAM size to 2048MB
+INFO         | Checking system compatibility:
+INFO         |   Checking: hasSufficientDiskSpace
+INFO         |      Ok: Disk space requirements to run avd: `Pixel` are met
+INFO         |   Checking: hasSufficientHwGpu
+INFO         |      Ok: Hardware GPU requirements to run avd: `Pixel` are passed
+INFO         |   Checking: hasSufficientSystem
+INFO         |      Ok: System requirements to run avd: `Pixel` are met
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_btn_xr_environment_living_room_day_clicked() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_btn_xr_environment_living_room_night_clicked() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_new_posture_requested(int) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_posture_selection_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_new_resizable_requested(PresetEmulatorSizeType) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_resizable_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_xr_environment_mode_changed(int) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_xr_environment_mode_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_xr_input_mode_changed(int) (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_dismiss_xr_input_mode_dialog() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_sleep_timer_done() (:0, )
+INFO         | Warning: QMetaObject::connectSlotsByName: No matching signal for on_unfold_timer_done() (:0, )
+INFO         | Storing crashdata in: /tmp/android-amiceli/emu-crash-35.5.2.db, detection is enabled for process: 92199
+INFO         | Guest Driver: Auto (ext controls)
+library_mode host gpu mode host
+INFO         | Initializing hardware OpenGLES emulation support
+I0721 21:49:02.352382 5065f00 opengles.cpp:285] android_startOpenglesRenderer: gpu info
+I0721 21:49:02.352392 5065f00 opengles.cpp:286] 
+INFO         | HealthMonitor disabled.
+INFO         | initIcdPaths: ICD set to 'swiftshader', using Swiftshader ICD
+INFO         | Setting ICD filenames for the loader = /nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/vk_swiftshader_icd.json:/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/vk_swiftshader_icd.json
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib]
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] (posix): begin
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] (posix,darwin): call dlopen
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] (posix,darwin): failed, try again with [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib]
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/qemu/darwin-aarch64/lib64/vulkan/libvulkan.dylib] failed (posix). dlerror: []
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib]
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib] (posix): begin
+
+INFO         | SharedLibrary::open for [/nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib] (posix,darwin): call dlopen
+
+INFO         | Added library: /nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib64/vulkan/libvulkan.dylib
+INFO         | Selecting Vulkan device: SwiftShader Device (LLVM 10.0.0), Version: 1.2.0
+INFO         | Supports id properties, got a vulkan device UUID
+INFO         | SharedLibrary::open for [/System/Library/Frameworks/OpenGL.framework/OpenGL]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [/System/Library/Frameworks/OpenGL.framework/OpenGL] (posix): begin
+
+INFO         | SharedLibrary::open for [/System/Library/Frameworks/OpenGL.framework/OpenGL] (posix,darwin): call dlopen
+
+INFO         | SharedLibrary::open for [libshadertranslator.dylib]: not found in map, open for the first time
+
+INFO         | SharedLibrary::open for [libshadertranslator.dylib] (posix): begin
+
+INFO         | SharedLibrary::open for [libshadertranslator.dylib] (posix,darwin): call dlopen
+
+INFO         | Initializing VkEmulation features:
+INFO         |     glInteropSupported: false
+INFO         |     useDeferredCommands: true
+INFO         |     createResourceWithRequirements: true
+INFO         |     useVulkanComposition: false
+INFO         |     useVulkanNativeSwapchain: false
+INFO         |     enable guestRenderDoc: false
+INFO         |     ASTC LDR emulation mode: 2
+INFO         |     enable ETC2 emulation: true
+INFO         |     enable Ycbcr emulation: false
+INFO         |     guestVulkanOnly: false
+INFO         |     useDedicatedAllocations: false
+INFO         | Graphics Adapter Vendor Google (Apple)
+INFO         | Graphics Adapter Android Emulator OpenGL ES Translator (Apple M3)
+INFO         | Graphics API Version OpenGL ES 3.0 (4.1 Metal - 89.4)
+INFO         | Graphics API Extensions GL_OES_EGL_sync GL_OES_EGL_image GL_OES_EGL_image_external GL_OES_depth24 GL_OES_depth32 GL_OES_element_index_uint GL_OES_texture_float GL_OES_texture_float_linear GL_OES_compressed_paletted_texture GL_OES_compressed_ETC1_RGB8_texture GL_OES_depth_texture GL_OES_texture_npot GL_OES_rgb8_rgba8 GL_EXT_color_buffer_float GL_EXT_color_buffer_half_float GL_EXT_texture_format_BGRA8888 GL_APPLE_texture_format_BGRA8888 
+INFO         | Graphics Device Extensions N/A
+INFO         | Sending adb public key [QAAAAIVjas+z4g2zV2PZy4jj+mLM9NhvmJz2yjVCQ4y+i5AkE1yQ1Qb99SEdLqSFyYxr1XwHDo20Y7HphQP2r1Yp+DE6j8cn6TUVj/0vvBLIR+z6/yW6JrYpRJoQCRfGShHWx1t3z2yHayK85lxxjBfLZPohjJhIwBOH93e/dkHzEOIkSM2c2dN+O5hX9gBXNFItznXZqfSTV+4bSknrRho8TXlxwCxCswk4UkXrbCsCdQmrHfFHVOAftL4f0QYJML6JoeHCQKGLqejgb1839FDDdEwDp9WXp9lCzCqW5/hLz/s8hnC/93vY0hC+Dh6K31rLihekJ/YfnlCOSefCErb55kh19deffD/sXhLBcfWnkB49jhvDf+HWSGbjQYUPMbBd+Rl4YGo2Fa0rJJ7Oolo36InMudIrCd7gojXYtj9vO6XPA9I93ftQgZMWYoFP3tbQRpWDnfBDT3JG5PZNFt3nV42OQSKB3O9MFJ/Y72Ev9mWxAx6vd1HYq+pT9YSR+K1znApOM+vVydeAczfXTUxknAGJWCExpPLKtLF268XCudhDhWXNBjxDDIteZcCR4gssOn87tHnf+fdrOZPqb98NqUd/Fs+bo0gRIVp3t0neF8KEdiYATfAKCVrjchziA66pSSMvHbRCnf+pn1Z9d+8mAjvLzRW51KipNbP40f8i9KUMGTIRPgEAAQA= amiceli@unknown]
+INFO         | Userspace boot properties:
+INFO         |   androidboot.boot_devices=a003600.virtio_mmio
+INFO         |   androidboot.dalvik.vm.heapsize=512m
+INFO         |   androidboot.debug.hwui.renderer=skiagl
+INFO         |   androidboot.hardware=ranchu
+INFO         |   androidboot.hardware.gltransport=pipe
+INFO         |   androidboot.hardware.vulkan=ranchu
+INFO         |   androidboot.logcat=*:V
+INFO         |   androidboot.opengles.version=196608
+INFO         |   androidboot.qemu=1
+INFO         |   androidboot.qemu.adb.pubkey=QAAAAIVjas+z4g2zV2PZy4jj+mLM9NhvmJz2yjVCQ4y+i5AkE1yQ1Qb99SEdLqSFyYxr1XwHDo20Y7HphQP2r1Yp+DE6j8cn6TUVj/0vvBLIR+z6/yW6JrYpRJoQCRfGShHWx1t3z2yHayK85lxxjBfLZPohjJhIwBOH93e/dkHzEOIkSM2c2dN+O5hX9gBXNFItznXZqfSTV+4bSknrRho8TXlxwCxCswk4UkXrbCsCdQmrHfFHVOAftL4f0QYJML6JoeHCQKGLqejgb1839FDDdEwDp9WXp9lCzCqW5/hLz/s8hnC/93vY0hC+Dh6K31rLihekJ/YfnlCOSefCErb55kh19deffD/sXhLBcfWnkB49jhvDf+HWSGbjQYUPMbBd+Rl4YGo2Fa0rJJ7Oolo36InMudIrCd7gojXYtj9vO6XPA9I93ftQgZMWYoFP3tbQRpWDnfBDT3JG5PZNFt3nV42OQSKB3O9MFJ/Y72Ev9mWxAx6vd1HYq+pT9YSR+K1znApOM+vVydeAczfXTUxknAGJWCExpPLKtLF268XCudhDhWXNBjxDDIteZcCR4gssOn87tHnf+fdrOZPqb98NqUd/Fs+bo0gRIVp3t0neF8KEdiYATfAKCVrjchziA66pSSMvHbRCnf+pn1Z9d+8mAjvLzRW51KipNbP40f8i9KUMGTIRPgEAAQA= amiceli@unknown
+INFO         |   androidboot.qemu.avd_name=Pixel
+INFO         |   androidboot.qemu.camera_hq_edge_processing=0
+INFO         |   androidboot.qemu.camera_protocol_ver=1
+INFO         |   androidboot.qemu.cpuvulkan.version=4202496
+INFO         |   androidboot.qemu.gltransport.drawFlushInterval=800
+INFO         |   androidboot.qemu.gltransport.name=pipe
+INFO         |   androidboot.qemu.hwcodec.avcdec=2
+INFO         |   androidboot.qemu.hwcodec.hevcdec=2
+INFO         |   androidboot.qemu.hwcodec.vpxdec=2
+INFO         |   androidboot.qemu.settings.system.screen_off_timeout=2147483647
+INFO         |   androidboot.qemu.virtiowifi=1
+INFO         |   androidboot.qemu.vsync=60
+INFO         |   androidboot.serialno=EMULATOR35X5X2X0
+INFO         |   androidboot.vbmeta.digest=017677f8986b0ac374dfb8d37fd142d50a77bda4a20142da493c5a4c3b962b87
+INFO         |   androidboot.vbmeta.hash_alg=sha256
+INFO         |   androidboot.vbmeta.size=6720
+INFO         |   androidboot.veritymode=enforcing
+INFO         | Monitoring duration of emulator setup.
+WARNING      | The emulator now requires a signed jwt token for gRPC access! Use the -grpc flag if you really want an open unprotected grpc port
+INFO         | Using security allow list from: /nix/store/yrj00xr4yqs94420xjpg0bfnx5r20yy7-android-sdk-emulator-35.5.2/libexec/android-sdk/emulator/lib/emulator_access.json
+WARNING      | *** Basic token auth should only be used by android-studio ***
+INFO         | The active JSON Web Key Sets can be found here: /Users/amiceli/Library/Caches/TemporaryItems/avd/running/92199/jwks/4c065025-b68c-4a9c-b6bd-cc1a4ae88fc7/active.jwk
+INFO         | Scanning /Users/amiceli/Library/Caches/TemporaryItems/avd/running/92199/jwks/4c065025-b68c-4a9c-b6bd-cc1a4ae88fc7 for jwk keys.
+INFO         | Started GRPC server at 127.0.0.1:8554, security: Local, auth: +token
+INFO         | Advertising in: /Users/amiceli/Library/Caches/TemporaryItems/avd/running/pid_92199.ini
+INFO         | Setting display: 0 configuration to: 1080x2400, dpi: 420x420 
+INFO         | setDisplayActiveConfig 0
+INFO         | Checking system compatibility:
+INFO         |   Checking: hasSufficientDiskSpace
+INFO         |      Ok: Disk space requirements to run avd: `Pixel` are met
+INFO         |   Checking: hasSufficientHwGpu
+INFO         |      Ok: Hardware GPU requirements to run avd: `Pixel` are passed
+INFO         |   Checking: hasSufficientSystem
+INFO         |      Ok: System requirements to run avd: `Pixel` are met
+INFO         | Loading snapshot 'default_boot'...
+WARNING      | Client not connected yet. Ignoring message!
+WARNING      | Client not connected yet. Ignoring message!
+WARNING      | Client not connected yet. Ignoring message!
+WARNING      | Unknown XR viewport mode requested: 0, ignored.
+
+INFO         | Successfully loaded snapshot 'default_boot'
+ERROR        | Failed to find ColorBuffer:0
+ERROR        | Failed to find ColorBuffer:0
+INFO         | Activated packet streamer for bluetooth emulation
+INFO         | Warning: skipping QEventPoint(id=1 ts=0 pos=0,0 scn=304.988,306.598 gbl=304.988,306.598 Released ellipse=(1x1 ∡ 0) vel=0,0 press=-304.988,-306.598 last=-304.988,-306.598 Δ 304.988,306.598) : no target window (:0, )
+INFO         | Wait for emulator (pid 92199) 20 seconds to shutdown gracefully before kill;you can set environment variable ANDROID_EMULATOR_WAIT_TIME_BEFORE_KILL(in seconds) to change the default value (20 seconds)
+
+INFO         | Saving with gfxstream=1
+ERROR        | Failed to restore previous context: 12297


### PR DESCRIPTION
On aarch64 systems, create arm avd, otherwise x86_64.

Commands:

- create-avd: create avd
- avd: launch avd

These allow explicit avd creation environment to environment. Android Studio will see these as available launch targets while running.